### PR TITLE
feat: trigger events when creating and updating submission

### DIFF
--- a/classes/event/assessable_uploaded.php
+++ b/classes/event/assessable_uploaded.php
@@ -1,0 +1,87 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The assignsubmission_qpy assessable uploaded event.
+ *
+ * @package    assignsubmission_qpy
+ * @copyright  2025 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace assignsubmission_qpy\event;
+
+use core\exception\moodle_exception;
+use moodle_url;
+
+/**
+ * The assignsubmission_qpy assessable uploaded event class.
+ *
+ * @package    assignsubmission_qpy
+ * @copyright  2025 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class assessable_uploaded extends \core\event\assessable_uploaded {
+    /**
+     * Returns the description of what happened.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return "The user with id '$this->userid' has created a QuestionPy submission with id '$this->objectid' " .
+            "in the assignment activity with course module id '$this->contextinstanceid'.";
+    }
+
+    /**
+     * Returns the localised event name.
+     *
+     * @return string
+     */
+    public static function get_name() {
+        return get_string('eventassessableuploaded', 'assignsubmission_qpy');
+    }
+
+    /**
+     * Get URL related to the action.
+     *
+     * @return moodle_url
+     * @throws moodle_exception
+     */
+    public function get_url() {
+        return new moodle_url('/mod/assign/view.php', ['id' => $this->contextinstanceid]);
+    }
+
+    /**
+     * Init method.
+     *
+     * @return void
+     */
+    protected function init() {
+        parent::init();
+        $this->data['objecttable'] = 'assign_submission';
+    }
+
+    /**
+     * This is used when restoring course logs where it is required that we map the objectid to its new value in the new course.
+     *
+     * See the docstring of {@see \core\event\base::get_objectid_mapping()} for more information.
+     *
+     * @return array
+     */
+    public static function get_objectid_mapping(): array {
+        return ['db' => 'assign_submission', 'restore' => 'submission'];
+    }
+}

--- a/classes/event/submission_created.php
+++ b/classes/event/submission_created.php
@@ -1,0 +1,70 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The assignsubmission_qpy submission_created event.
+ *
+ * @package    assignsubmission_qpy
+ * @copyright  2025 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace assignsubmission_qpy\event;
+
+/**
+ * The assignsubmission_qpy submission_created event class.
+ *
+ * @package    assignsubmission_qpy
+ * @copyright  2025 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class submission_created extends \mod_assign\event\submission_created {
+    /**
+     * Init method.
+     */
+    protected function init(): void {
+        parent::init();
+        $this->data['objecttable'] = 'assignsubmission_qpy';
+    }
+
+    /**
+     * Returns the description of what happened.
+     *
+     * @return string
+     */
+    public function get_description(): string {
+        $descriptionstring = "The user with id '$this->userid' created a QuestionPy submission in the assignment with course " .
+            "module id '$this->contextinstanceid'";
+        if (!empty($this->other['groupid'])) {
+            $descriptionstring .= " for the group with id '{$this->other['groupid']}'.";
+        } else {
+            $descriptionstring .= '.';
+        }
+
+        return $descriptionstring;
+    }
+
+    /**
+     * This is used when restoring course logs where it is required that we map the objectid to its new value in the new course.
+     *
+     * See the docstring of {@see \core\event\base::get_objectid_mapping()} for more information.
+     *
+     * @return int
+     */
+    public static function get_objectid_mapping(): int {
+        return \core\event\base::NOT_MAPPED;
+    }
+}

--- a/classes/event/submission_updated.php
+++ b/classes/event/submission_updated.php
@@ -1,0 +1,70 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The assignsubmission_qpy submission_updated event.
+ *
+ * @package    assignsubmission_qpy
+ * @copyright  2025 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace assignsubmission_qpy\event;
+
+/**
+ * The assignsubmission_qpy submission_updated event class.
+ *
+ * @package    assignsubmission_qpy
+ * @copyright  2025 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class submission_updated extends \mod_assign\event\submission_updated {
+    /**
+     * Init method.
+     */
+    protected function init(): void {
+        parent::init();
+        $this->data['objecttable'] = 'assignsubmission_qpy';
+    }
+
+    /**
+     * Returns the description of what happened.
+     *
+     * @return string
+     */
+    public function get_description(): string {
+        $descriptionstring = "The user with id '$this->userid' updated a QuestionPy submission in the assignment with course " .
+            "module id '$this->contextinstanceid'";
+        if (!empty($this->other['groupid'])) {
+            $descriptionstring .= " for the group with id '{$this->other['groupid']}'.";
+        } else {
+            $descriptionstring .= '.';
+        }
+
+        return $descriptionstring;
+    }
+
+    /**
+     * This is used when restoring course logs where it is required that we map the objectid to its new value in the new course.
+     *
+     * See the docstring of {@see \core\event\base::get_objectid_mapping()} for more information.
+     *
+     * @return int
+     */
+    public static function get_objectid_mapping(): int {
+        return \core\event\base::NOT_MAPPED;
+    }
+}

--- a/db/install.xml
+++ b/db/install.xml
@@ -9,7 +9,8 @@
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="assignment" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="submission" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="questionusageid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" />
+        <FIELD NAME="questionusageid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="issaved" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="This assignment submission was explicitly saved by a student."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/lang/en/assignsubmission_qpy.php
+++ b/lang/en/assignsubmission_qpy.php
@@ -24,6 +24,7 @@
 
 $string['enabled'] = 'QuestionPy submissions';
 $string['enabled_help'] = 'If enabled, students are able to answer QuestionPy questions.';
+$string['eventassessableuploaded'] = 'QuestionPy assessable uploaded';
 $string['pluginname'] = 'QuestionPy submission';
 $string['questionnotfound'] = 'Question not found.';
 $string['questionnotgradable'] = 'The question was not answered or was answered incompletely.';

--- a/locallib.php
+++ b/locallib.php
@@ -22,6 +22,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use assignsubmission_qpy\event\assessable_uploaded;
+use assignsubmission_qpy\event\submission_created;
+use assignsubmission_qpy\event\submission_updated;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir . '/questionlib.php');
@@ -152,8 +156,6 @@ class assign_submission_qpy extends assign_submission_plugin {
      * @return boolean - true if we added anything to the form
      */
     public function get_form_elements_for_user($submission, MoodleQuickForm $mform, stdClass $data, $userid) {
-        global $DB;
-
         if ($submission === null) {
             $mform->addElement('html', 'Keine Submission vorhanden!'); // TODO.
             return true;
@@ -203,30 +205,35 @@ class assign_submission_qpy extends assign_submission_plugin {
      * @param int $submissionid
      * @param question_usage_by_activity|null $basedon
      * @return question_usage_by_activity
+     * @throws moodle_exception
      */
     private function create_question_usage_attempt(
         int $submissionid, ?question_usage_by_activity $basedon = null
     ): question_usage_by_activity {
         global $DB;
 
+        // Get the question.
         $questionid = $this->get_question_id();
         if ($questionid === null) {
             throw new moodle_exception('questionnotfound', 'assignsubmission_qpy');
         }
+        $question = question_bank::load_question($questionid);
 
-        $transaction = $DB->start_delegated_transaction();
-
+        // Create a new question usage.
         $quba = question_engine::make_questions_usage_by_activity('assignsubmission_qpy', $this->assignment->get_context());
         $quba->set_preferred_behaviour($this->get_config('preferredbehaviour'));
 
-        $question = question_bank::load_question($questionid);
-        $quba->add_question($question, null);
+        $quba->add_question($question);
         if ($basedon) {
             $oldqa = $basedon->get_question_attempt($basedon->get_first_question_number());
             $quba->start_question_based_on($quba->get_first_question_number(), $oldqa);
         } else {
             $quba->start_all_questions();
         }
+
+        $transaction = $DB->start_delegated_transaction();
+
+        // Save the question usage.
         question_engine::save_questions_usage_by_activity($quba);
 
         // Save usageid in our table.
@@ -249,14 +256,14 @@ class assign_submission_qpy extends assign_submission_plugin {
      */
     private function get_question_usage($submission, bool $mustexist = true): ?question_usage_by_activity {
         global $DB;
-        $qpysubmission = $DB->get_record('assignsubmission_qpy', ['submission' => $submission->id]);
-        if ($qpysubmission === false) {
+        $questionusageid = $DB->get_field('assignsubmission_qpy', 'questionusageid', ['submission' => $submission->id]);
+        if ($questionusageid === false) {
             if ($mustexist) {
                 throw new \moodle_exception('submissionnotfound', 'assignsubmission_qpy');
             }
             return null;
         }
-        return question_engine::load_questions_usage_by_activity($qpysubmission->questionusageid);
+        return question_engine::load_questions_usage_by_activity($questionusageid);
     }
 
     /**
@@ -289,24 +296,72 @@ class assign_submission_qpy extends assign_submission_plugin {
      * @param stdClass $submission
      * @param stdClass $data
      * @return bool
+     * @throws moodle_exception
      */
     public function save(stdClass $submission, stdClass $data) {
-        global $DB;
+        global $DB, $USER;
 
-        $transaction = $DB->start_delegated_transaction();
+        $params = [
+            'context' => context_module::instance($this->assignment->get_course_module()->id),
+            'courseid' => $this->assignment->get_course()->id,
+            'objectid' => $submission->id,
+            'other' => [
+                'content' => '',
+                'pathnamehashes' => [],
+            ],
+        ];
+
+        if (!empty($submission->userid) && ($submission->userid != $USER->id)) {
+            $params['relateduserid'] = $submission->userid;
+        }
+
+        $event = assessable_uploaded::create($params);
+        $event->trigger();
+
+        // Get the group name as other fields are not transcribed in the logs and this information is important.
+        if (empty($submission->userid) && !empty($submission->groupid)) {
+            $groupname = $DB->get_field('groups', 'name', ['id' => $submission->groupid], MUST_EXIST);
+            $groupid = $submission->groupid;
+        } else {
+            $params['relateduserid'] = $submission->userid;
+        }
+
+        // Unset the 'other' and 'objectid' field from params for use in submission events.
+        unset($params['other'], $params['objectid']);
+
+        $params['other'] = [
+            'submissionid' => $submission->id,
+            'submissionattempt' => $submission->attemptnumber,
+            'submissionstatus' => $submission->status,
+            'groupid' => $groupid ?? 0,
+            'groupname' => $groupname ?? null,
+        ];
+
+        // Save the question usage.
         $quba = $this->get_question_usage($submission);
         $quba->process_all_actions();
         question_engine::save_questions_usage_by_activity($quba);
-        $transaction->allow_commit();
 
-        // TODO: trigger event, submission updated.
+        // Trigger created- or updated-event.
+        $qpysubmission = $DB->get_record('assignsubmission_qpy', ['submission' => $submission->id], 'id, issaved', MUST_EXIST);
+        $params['objectid'] = $qpysubmission->id;
+
+        if ($qpysubmission->issaved == 0) {
+            $event = submission_created::create($params);
+            $DB->set_field('assignsubmission_qpy', 'issaved', '1');
+        } else {
+            $event = submission_updated::create($params);
+        }
+        $event->set_assign($this->assignment);
+        $event->trigger();
+
         return true;
     }
 
     /**
      * Information to be displayed about the submission.
      *
-     * This is diplayed on multiple pages and should actually only show a summary.
+     * This is displayed on multiple pages and should actually only show a summary.
      *
      * @param stdClass $submission
      * @param bool $showviewlink

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'assignsubmission_qpy';
-$plugin->version = 2025080500;
+$plugin->version = 2025092500;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_ALPHA;
 $plugin->release = '0.1';


### PR DESCRIPTION
Closes #2

Ich hatte zunächst versucht in `save()` die Question-Usage zu speichern und den Eintrag in der `assignsubmission_qpy`-Tabelle zu erstellen. Letzteres wirkt für mich an der Stelle zumindest passender, als `get_form_elements_for_user()` und alle Plugins, die ich mir angeschaut habe, machen das auch in `save()`. Das funktioniert leider nicht ohne Weiteres / Hacks (?) mit der Question-Usage.