### PR TITLE
Auswahl der Fragenversion und Neubewertung

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -1,0 +1,53 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace assignsubmission_qpy;
+
+/**
+ * Helper methods for the mod_assign QuestionPy submission plugin.
+ *
+ * @package    assignsubmission_qpy
+ * @copyright  2025 Martin Gauk, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class helper {
+    /**
+     * Get the question id for an assignment instance.
+     *
+     * @param \assign $assignment
+     * @return int|null
+     */
+    public static function get_question_id(\assign $assignment): ?int {
+        global $DB;
+
+        if (!$assignment->has_instance()) {
+            return null;
+        }
+
+        $id = $DB->get_field_sql("
+            SELECT qv.questionid
+              FROM {question_references} qr
+              JOIN {question_versions} qv ON
+                       (qv.questionbankentryid = qr.questionbankentryid AND qv.version = qr.version)
+             WHERE qr.usingcontextid = :context AND qr.component = 'assignsubmission_qpy'
+                       AND qr.questionarea = 'main' AND qr.itemid = :itemid", [
+            'context' => $assignment->get_context()->id,
+            'itemid' => $assignment->get_default_instance()->id,
+        ]);
+
+        return ($id !== false) ? intval($id) : null;
+    }
+}

--- a/classes/task/regrade_all.php
+++ b/classes/task/regrade_all.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace assignsubmission_qpy\task;
+
+defined('MOODLE_INTERNAL') || die();
+
+use core\context\module;
+use assignsubmission_qpy\helper;
+
+require_once($CFG->libdir . '/questionlib.php');
+require_once($CFG->dirroot . '/mod/assign/locallib.php');
+
+/**
+ * Ad-hoc task to regrade all submissions for an assignment.
+ *
+ * @package    assignsubmission_qpy
+ * @copyright  2025 Martin Gauk, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class regrade_all extends \core\task\adhoc_task {
+    /**
+     * Execute the task.
+     */
+    public function execute() {
+        global $DB;
+
+        $data = $this->get_custom_data();
+        $context = module::instance($data->cmid);
+        $assignment = new \assign($context, null, null);
+        $assignmentdefaultinstance = $assignment->get_default_instance();
+        $questionid = helper::get_question_id($assignment);
+
+        $newmaxscore = ($assignmentdefaultinstance->grade > 0) ? $assignmentdefaultinstance->grade : null;
+
+        // Get all submissions for this assignment.
+        $usageids = $DB->get_fieldset(
+            'assignsubmission_qpy',
+            'questionusageid',
+            ['assignment' => $assignmentdefaultinstance->id],
+        );
+
+        $count = 0;
+        foreach ($usageids as $usageid) {
+            try {
+                $quba = \question_engine::load_questions_usage_by_activity($usageid);
+                $question = \question_bank::load_question($questionid);
+                $quba->regrade_question($quba->get_first_question_number(), false, $newmaxscore, $question);
+                \question_engine::save_questions_usage_by_activity($quba);
+                $count++;
+                mtrace("Regraded submission with questionusageid $usageid.");
+            } catch (\Exception $e) {
+                // Log the error but continue with other submissions.
+                mtrace("Error regrading submission with questionusageid $usageid: " . $e->getMessage());
+            }
+        }
+
+        mtrace("Regraded $count submissions for assignment with cmid {$data->cmid}.");
+    }
+}

--- a/lang/en/assignsubmission_qpy.php
+++ b/lang/en/assignsubmission_qpy.php
@@ -34,4 +34,6 @@ $string['questionnotgradable'] = 'The question was not answered or was answered 
 $string['questionpyrequired'] = 'Only QuestionPy questions are allowed.';
 $string['questionversion'] = 'v{$a}';
 $string['questionversion_select'] = 'Question version';
+$string['regradeall'] = 'Regrade all submissions (in background)';
+$string['regradeall_help'] = 'If checked, all existing submissions for this assignment will be regraded using the selected question version. This process runs in the background.';
 $string['submissionnotfound'] = 'No question submission found.';

--- a/lang/en/assignsubmission_qpy.php
+++ b/lang/en/assignsubmission_qpy.php
@@ -32,4 +32,6 @@ $string['questionnopermission'] = 'You do not have permission to access this que
 $string['questionnotfound'] = 'Question not found.';
 $string['questionnotgradable'] = 'The question was not answered or was answered incompletely.';
 $string['questionpyrequired'] = 'Only QuestionPy questions are allowed.';
+$string['questionversion'] = 'v{$a}';
+$string['questionversion_select'] = 'Question version';
 $string['submissionnotfound'] = 'No question submission found.';

--- a/locallib.php
+++ b/locallib.php
@@ -25,6 +25,7 @@
 use assignsubmission_qpy\event\assessable_uploaded;
 use assignsubmission_qpy\event\submission_created;
 use assignsubmission_qpy\event\submission_updated;
+use assignsubmission_qpy\helper;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -59,7 +60,7 @@ class assign_submission_qpy extends assign_submission_plugin {
     public function get_settings(MoodleQuickForm $mform) {
         global $DB;
 
-        $defaultquestionid = $this->get_question_id() ?? 0;
+        $defaultquestionid = helper::get_question_id($this->assignment) ?? 0;
         if ($this->assignment->has_instance()) {
             $defaultbehaviour = $this->get_config('preferredbehaviour');
         } else {
@@ -101,6 +102,15 @@ class assign_submission_qpy extends assign_submission_plugin {
             );
             $mform->setDefault('assignsubmission_qpy_questionid', $defaultquestionid);
             $mform->hideIf('assignsubmission_qpy_questionid', 'assignsubmission_qpy_enabled', 'notchecked');
+
+            // Add checkbox to regrade all submissions.
+            $mform->addElement(
+                'advcheckbox',
+                'assignsubmission_qpy_regradeall',
+                get_string('regradeall', 'assignsubmission_qpy')
+            );
+            $mform->addHelpButton('assignsubmission_qpy_regradeall', 'regradeall', 'assignsubmission_qpy');
+            $mform->hideIf('assignsubmission_qpy_regradeall', 'assignsubmission_qpy_enabled', 'notchecked');
         } else {
             // No submissions yet, show the question ID text field.
             // TODO: We should add a selector here with all questions in course question banks.
@@ -211,10 +221,17 @@ class assign_submission_qpy extends assign_submission_plugin {
             $updateref->version = $qv->version;
             $DB->update_record('question_references', $updateref);
         }
-        return true;
 
-        // TODO: If there are already submissions, only allow to change question version.
-        // TODO: Regrading if other question version selected?
+        // Schedule regrade task if checkbox was checked.
+        if (!empty($data->assignsubmission_qpy_regradeall)) {
+            $task = new \assignsubmission_qpy\task\regrade_all();
+            $task->set_custom_data([
+                'cmid' => $this->assignment->get_course_module()->id,
+            ]);
+            \core\task\manager::queue_adhoc_task($task, true);
+        }
+
+        return true;
     }
 
     /**
@@ -247,32 +264,6 @@ class assign_submission_qpy extends assign_submission_plugin {
     }
 
     /**
-     * Get the question id for this assignment.
-     *
-     * @return int|null
-     */
-    private function get_question_id(): ?int {
-        global $DB;
-
-        if (!$this->assignment->has_instance()) {
-            return null;
-        }
-
-        $id = $DB->get_field_sql("
-            SELECT qv.questionid
-              FROM {question_references} qr
-              JOIN {question_versions} qv ON
-                       (qv.questionbankentryid = qr.questionbankentryid AND qv.version = qr.version)
-             WHERE qr.usingcontextid = :context AND qr.component = 'assignsubmission_qpy'
-                       AND qr.questionarea = 'main' AND qr.itemid = :itemid", [
-            'context' => $this->assignment->get_context()->id,
-            'itemid' => $this->assignment->get_default_instance()->id,
-        ]);
-
-        return ($id !== false) ? intval($id) : null;
-    }
-
-    /**
      * Create a question usage for the current user and add the question.
      *
      * @param stdClass $submission
@@ -286,7 +277,7 @@ class assign_submission_qpy extends assign_submission_plugin {
         global $DB;
 
         // Get the question.
-        $questionid = $this->get_question_id();
+        $questionid = helper::get_question_id($this->assignment);
         if ($questionid === null) {
             throw new moodle_exception('questionnotfound', 'assignsubmission_qpy');
         }

--- a/locallib.php
+++ b/locallib.php
@@ -57,6 +57,8 @@ class assign_submission_qpy extends assign_submission_plugin {
      * @return void
      */
     public function get_settings(MoodleQuickForm $mform) {
+        global $DB;
+
         $defaultquestionid = $this->get_question_id() ?? 0;
         if ($this->assignment->has_instance()) {
             $defaultbehaviour = $this->get_config('preferredbehaviour');
@@ -64,10 +66,49 @@ class assign_submission_qpy extends assign_submission_plugin {
             $defaultbehaviour = 'deferredfeedback';
         }
 
-        $mform->addElement('text', 'assignsubmission_qpy_questionid', 'Question ID');
-        $mform->setDefault('assignsubmission_qpy_questionid', $defaultquestionid);
-        $mform->setType('assignsubmission_qpy_questionid', PARAM_INT);
-        $mform->hideIf('assignsubmission_qpy_questionid', 'assignsubmission_qpy_enabled', 'notchecked');
+        // Check if there are already submissions.
+        $hassubmissions = false;
+        if ($this->assignment->has_instance()) {
+            $assignid = $this->assignment->get_instance()->id;
+            $hassubmissions = $DB->record_exists('assignsubmission_qpy', ['assignment' => $assignid]);
+        }
+
+        if ($hassubmissions && $defaultquestionid > 0) {
+            // If submissions exist, show a version selector instead of question ID field.
+            $entryid = $DB->get_field(
+                'question_versions',
+                'questionbankentryid',
+                ['questionid' => $defaultquestionid],
+                MUST_EXIST
+            );
+            $versions = $DB->get_records(
+                'question_versions',
+                ['questionbankentryid' => $entryid],
+                'version DESC',
+                'questionid, version'
+            );
+
+            $versionoptions = [];
+            foreach ($versions as $version) {
+                $versionoptions[$version->questionid] = get_string('questionversion', 'assignsubmission_qpy', $version->version);
+            }
+
+            $mform->addElement(
+                'select',
+                'assignsubmission_qpy_questionid',
+                get_string('questionversion_select', 'assignsubmission_qpy'),
+                $versionoptions
+            );
+            $mform->setDefault('assignsubmission_qpy_questionid', $defaultquestionid);
+            $mform->hideIf('assignsubmission_qpy_questionid', 'assignsubmission_qpy_enabled', 'notchecked');
+        } else {
+            // No submissions yet, show the question ID text field.
+            // TODO: We should add a selector here with all questions in course question banks.
+            $mform->addElement('text', 'assignsubmission_qpy_questionid', 'Question ID');
+            $mform->setDefault('assignsubmission_qpy_questionid', $defaultquestionid);
+            $mform->setType('assignsubmission_qpy_questionid', PARAM_INT);
+            $mform->hideIf('assignsubmission_qpy_questionid', 'assignsubmission_qpy_enabled', 'notchecked');
+        }
 
         $behaviours = question_engine::get_behaviour_options($defaultbehaviour);
         $mform->addElement(


### PR DESCRIPTION
Wenn bereits Abgaben (bzw. question usages) vorliegen, kann man als Trainer nur noch die Fragenversion ändern und keine komplett andere Frage (ID) angeben. Optional kann auch eine Neubewertung ausgeführt werden, die im Hintergrund per ad-hoc Task läuft.