### PR TITLE
fix: `get_context()` might return `null`

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -108,7 +108,7 @@ class assign_submission_qpy extends assign_submission_plugin {
         // but this requirement is safer for us (in case we forgot some additional checks).
         $question = question_bank::load_question($questionid);
         $questioncoursecontext = context::instance_by_id($question->contextid)->get_course_context();
-        $assigncoursecontext = $this->assignment->get_context()->get_course_context();
+        $assigncoursecontext = $this->assignment->get_course_context();
         if (
             $questioncoursecontext->id != $assigncoursecontext->id ||
             !question_has_capability_on($question, 'use') ||


### PR DESCRIPTION
Beim ursprünglichen Testen wurde mir dieser Fehler nicht angezeigt (auch nach dem Updaten auf 5.0). Nachdem ich Moodle nochmal neu aufgesetzt habe, bekomme ich diesen Fehler beim Erstellen einer QPy-Submission: 
<img width="798" height="493" alt="image" src="https://github.com/user-attachments/assets/eea3682c-a700-4332-b85e-e47bf55eb178" />
Mit der Änderung passiert das nicht.