### PR TITLE
fix: only validate when qpy is selected

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -94,6 +94,11 @@ class assign_submission_qpy extends assign_submission_plugin {
     public function settings_validation(array $data, array $files): array {
         global $DB;
 
+        // This should be handled by Moodle, but it is not.
+        if (empty($data['assignsubmission_qpy_enabled'])) {
+            return [];
+        }
+
         $errors = [];
         $questionid = $data['assignsubmission_qpy_questionid'];
 


### PR DESCRIPTION
Fixes #8 

Meiner Meinung nach sollte die `settings_validation`-Methode nur aufgerufen werden, wenn das Plugin ausgewählt wurde. Aktuell wird diese Methode aber von allen Plugins aufgerufen, die enabled sind ([siehe](https://github.com/moodle/moodle/blob/0efd4011adb6094ada05b825879e3a5f5384ca0b/public/mod/assign/locallib.php#L1776-L1780) und [siehe](https://github.com/moodle/moodle/blob/0efd4011adb6094ada05b825879e3a5f5384ca0b/public/mod/assign/assignmentplugin.php#L301-L312)).