### PR TITLE
Dateien aus der Frage downloadbar machen

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -16,6 +16,14 @@
 
 namespace assignsubmission_qpy;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/mod/assign/locallib.php');
+require_once($CFG->libdir . '/questionlib.php');
+
+use core\context;
+use question_display_options;
+
 /**
  * Helper methods for the mod_assign QuestionPy submission plugin.
  *
@@ -49,5 +57,99 @@ class helper {
         ]);
 
         return ($id !== false) ? intval($id) : null;
+    }
+
+    /**
+     * Get the question display options for a submission.
+     *
+     * @param \assign $assignment
+     * @param \stdClass $submission
+     * @param bool $review read-only/review mode
+     * @param bool $mayshowhistory display response history if the user has the capability
+     * @return question_display_options
+     */
+    public static function get_question_display_options(
+        \assign $assignment,
+        \stdClass $submission,
+        bool $review,
+        bool $mayshowhistory,
+    ): question_display_options {
+        $context = $assignment->get_context();
+
+        $displayoptions = new question_display_options();
+        $displayoptions->readonly = $review;
+
+        // Setting $marks works, $correctness gets overwritten / ignored by qbehaviour_adaptive, but we hide it in CSS.
+        $displayoptions->marks = question_display_options::HIDDEN;
+        $displayoptions->correctness = question_display_options::HIDDEN;
+        $displayoptions->flags = question_display_options::HIDDEN;
+        $displayoptions->history = question_display_options::HIDDEN;
+
+        if ($mayshowhistory && has_capability('mod/assign:grade', $context)) {
+            $displayoptions->history = question_display_options::VISIBLE;
+
+            // The attribute userinfoinhistory is either question_display_options::HIDDEN or the id of the user
+            // who owns the question attempt. Moodle only displays the name of the user to whom an attempt step
+            // belongs if their ID is different to userinfoinhistory.
+            if ($assignment->is_blind_marking() && !has_capability('mod/assign:viewblinddetails', $context)) {
+                $displayoptions->userinfoinhistory = question_display_options::HIDDEN;
+            } else if ($assignment->get_instance()->teamsubmission) {
+                $displayoptions->userinfoinhistory = 1; // Display all names (as 1 is the guest user id).
+            } else {
+                $displayoptions->userinfoinhistory = $submission->userid; // Only display a name if different from this user.
+            }
+        }
+
+        return $displayoptions;
+    }
+
+    /**
+     * Get the assignment object for a submission and check access permissions for the current user.
+     *
+     * @param context $context
+     * @param \stdClass|null $cm
+     * @param \stdClass $course
+     * @param \stdClass $submission
+     * @return \assign
+     */
+    public static function get_assignment_and_check_access(
+        context $context,
+        ?\stdClass $cm,
+        \stdClass $course,
+        \stdClass $submission
+    ): \assign {
+        if ($context->contextlevel != CONTEXT_MODULE) {
+            throw new \moodle_exception('invalidcourselevel', 'error');
+        }
+
+        if (!$cm) {
+            [, $cm] = get_course_and_cm_from_cmid($context->instanceid, 'assign', $course);
+        }
+
+        require_login($course, false, $cm);
+        $assign = new \assign($context, $cm, $course);
+
+        // Verify that the submission belongs to this assignment activity.
+        if ($assign->get_instance()->id != $submission->assignment) {
+            throw new \moodle_exception('nopermissions', 'error');
+        }
+
+        // Check team submission permissions.
+        if (
+            $assign->get_instance()->teamsubmission &&
+            !$assign->can_view_group_submission($submission->groupid)
+        ) {
+            throw new \moodle_exception('nopermissions', 'error');
+        }
+
+        // Check individual submission permissions.
+        if (
+            !$assign->get_instance()->teamsubmission &&
+            !$assign->can_view_submission($submission->userid)
+        ) {
+            throw new \moodle_exception('nopermissions', 'error');
+        }
+
+        return $assign;
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -48,45 +48,17 @@ function assignsubmission_qpy_pluginfile(
     array $options = []
 ): bool {
     // Almost entirely identical to assignsubmission_file_pluginfile.
-    global $DB, $CFG;
+    global $DB;
 
-    if ($context->contextlevel != CONTEXT_MODULE) {
-        return false;
-    }
-
-    require_login($course, false, $cm);
     $itemid = (int)array_shift($args);
-    $record = $DB->get_record(
+    $submission = $DB->get_record(
         'assign_submission',
         ['id' => $itemid],
         'userid, assignment, groupid',
         MUST_EXIST
     );
-    $userid = $record->userid;
-    $groupid = $record->groupid;
 
-    require_once($CFG->dirroot . '/mod/assign/locallib.php');
-
-    $assign = new assign($context, $cm, $course);
-
-    if ($assign->get_instance()->id != $record->assignment) {
-        return false;
-    }
-
-    if (
-        $assign->get_instance()->teamsubmission &&
-        !$assign->can_view_group_submission($groupid)
-    ) {
-        return false;
-    }
-
-    if (
-        !$assign->get_instance()->teamsubmission &&
-        !$assign->can_view_submission($userid)
-    ) {
-        return false;
-    }
-
+    \assignsubmission_qpy\helper::get_assignment_and_check_access($context, $cm, $course, $submission);
     $relativepath = implode('/', $args);
 
     $fullpath = "/{$context->id}/assignsubmission_qpy/$filearea/$itemid/$relativepath";
@@ -98,4 +70,67 @@ function assignsubmission_qpy_pluginfile(
 
     // Download MUST be forced - security!
     send_stored_file($file, 0, 0, true, $options);
+}
+
+/**
+ * Serves files within question attempts.
+ *
+ * Called via pluginfile.php -> question_pluginfile to serve files belonging to
+ * a question in a question_attempt when that attempt is a quiz attempt.
+ *
+ * @param stdClass $course course settings object
+ * @param \core\context $context context object
+ * @param string $component the name of the component we are serving files for.
+ * @param string $filearea the name of the file area.
+ * @param int $qubaid the attempt usage id.
+ * @param int $slot the id of a question in this quiz attempt.
+ * @param array $args the remaining bits of the file path.
+ * @param bool $forcedownload whether the user must be forced to download the file.
+ * @param array $options additional options affecting the file serving
+ * @return bool false if file not found, does not return if found - justsend the file
+ * @package  mod_quiz
+ * @category files
+ */
+function assignsubmission_qpy_question_pluginfile(
+    $course,
+    $context,
+    $component,
+    $filearea,
+    $qubaid,
+    $slot,
+    $args,
+    $forcedownload,
+    array $options = []
+): bool {
+    global $DB;
+
+    $submission = $DB->get_record_sql(
+        'SELECT s.*
+         FROM {assignsubmission_qpy} q
+         JOIN {assign_submission} s ON (s.id = q.submission)
+         WHERE q.questionusageid = :usageid',
+        ['usageid' => $qubaid],
+        MUST_EXIST
+    );
+
+    $assign = \assignsubmission_qpy\helper::get_assignment_and_check_access($context, null, $course, $submission);
+    $quba = \question_engine::load_questions_usage_by_activity($qubaid);
+    $displayoptions = \assignsubmission_qpy\helper::get_question_display_options(
+        $assign,
+        $submission,
+        review: true,
+        mayshowhistory: false
+    );
+    if (!$quba->check_file_access($slot, $displayoptions, $component, $filearea, $args, $forcedownload)) {
+        send_file_not_found();
+    }
+
+    $fs = get_file_storage();
+    $relativepath = implode('/', $args);
+    $fullpath = "/$context->id/$component/$filearea/$relativepath";
+    if (!($file = $fs->get_file_by_hash(sha1($fullpath))) || $file->is_directory()) {
+        return false;
+    }
+
+    send_stored_file($file, 0, 0, $forcedownload, $options);
 }

--- a/locallib.php
+++ b/locallib.php
@@ -265,8 +265,12 @@ class assign_submission_qpy extends assign_submission_plugin {
             $quba = $this->create_question_usage_attempt($submission);
         }
 
-        $displayoptions = new question_display_options();
-        $displayoptions->flags = question_display_options::HIDDEN;
+        $displayoptions = helper::get_question_display_options(
+            $this->assignment,
+            $submission,
+            review: false,
+            mayshowhistory: false,
+        );
         $questionhtml = $quba->render_question($quba->get_first_question_number(), $displayoptions);
         $mform->addElement('html', $questionhtml);
         return true;
@@ -570,26 +574,12 @@ class assign_submission_qpy extends assign_submission_plugin {
             return '';
         }
 
-        $assignmentinstance = $this->assignment->get_instance();
-        $context = $this->assignment->get_context();
-
-        $displayoptions = new question_display_options();
-        $displayoptions->readonly = true;
-        $displayoptions->flags = question_display_options::HIDDEN;
-        $displayoptions->history = question_display_options::HIDDEN;
-
-        if ($mayshowhistory && has_capability('mod/assign:grade', $context)) {
-            $displayoptions->history = question_display_options::VISIBLE;
-
-            if ($this->assignment->is_blind_marking() && !has_capability('mod/assign:viewblinddetails', $context)) {
-                $displayoptions->userinfoinhistory = question_display_options::HIDDEN;
-            } else if ($assignmentinstance->teamsubmission) {
-                $displayoptions->userinfoinhistory = 1; // Display all names.
-            } else {
-                $displayoptions->userinfoinhistory = $submission->userid; // Only display a name if different from this user.
-            }
-        }
-
+        $displayoptions = helper::get_question_display_options(
+            $this->assignment,
+            $submission,
+            review: true,
+            mayshowhistory: true
+        );
         $quba->preload_all_step_users();
         return $quba->render_question($quba->get_first_question_number(), $displayoptions);
     }


### PR DESCRIPTION
Die Question API verlangt, dass Plugins, die Fragen einbinden, eine Funktion `_question_pluginfile` implementieren müssen mit den entsprechenden Überprüfungen, ob der User den Attempt sehen darf und mit welchen Display Options.

Die in #13 angedachte Anpassung der Display Options habe ich aufgenommen, um der Einfachheit halber einem Konflikt aus den Weg zu gehen.