### PR TITLE
feat: show form data with collapsible containers

### DIFF
--- a/lang/en/assignsubmission_qpy.php
+++ b/lang/en/assignsubmission_qpy.php
@@ -39,6 +39,4 @@ $string['questionversion_select'] = 'Question version';
 $string['regradeall'] = 'Regrade all submissions (in background)';
 $string['regradeall_help'] = 'If checked, all existing submissions for this assignment will be regraded using the selected question version. This process runs in the background.';
 $string['submissionnotfound'] = 'No question submission found.';
-$string['summaryresponsefiles'] = '{$a} files were part of the submission:';
 $string['summaryresponsestring'] = '<code>{$a->key}</code> = <code>"{$a->value}"</code>';
-$string['summarytoomanyitems'] = '{$a->responsefieldcount} response fields and {$a->filecount} files';

--- a/lang/en/assignsubmission_qpy.php
+++ b/lang/en/assignsubmission_qpy.php
@@ -39,4 +39,4 @@ $string['questionversion_select'] = 'Question version';
 $string['regradeall'] = 'Regrade all submissions (in background)';
 $string['regradeall_help'] = 'If checked, all existing submissions for this assignment will be regraded using the selected question version. This process runs in the background.';
 $string['submissionnotfound'] = 'No question submission found.';
-$string['summaryresponsestring'] = '<code>{$a->key}</code> = <code>"{$a->value}"</code>';
+$string['summaryresponsestring'] = '<code>{$a->key}</code> = <code>{$a->value}</code>';

--- a/locallib.php
+++ b/locallib.php
@@ -510,10 +510,10 @@ class assign_submission_qpy extends assign_submission_plugin {
         if (
             !(str_ends_with($_SERVER['SCRIPT_NAME'], 'view.php') && optional_param('action', '', PARAM_ALPHANUMEXT) === 'grading')
         ) {
-            // The grading page has a long table. Do not display the full submission.
             return $this->view($submission, false);
         }
 
+        // The grading page has a long table. Do not display the full submission.
         $showviewlink = true; // Always show the link to view the attempt and history.
         $quba = $this->get_question_usage($submission);
         $attempt = $quba->get_question_attempt($quba->get_first_question_number());
@@ -536,6 +536,31 @@ class assign_submission_qpy extends assign_submission_plugin {
         $opened = count($response) + count($dynamicdata) + count($files) < self::COLLAPSIBLE_OPENED_THRESHOLD;
 
         $html = '';
+
+        if ($files) {
+            $filelistitems = [];
+            foreach ($files as $file) {
+                $fileurl = moodle_url::make_pluginfile_url(
+                    $file->get_contextid(),
+                    $file->get_component(),
+                    $file->get_filearea(),
+                    $file->get_itemid(),
+                    $file->get_filepath(),
+                    $file->get_filename()
+                );
+                $linktext = $file->get_filename() . ' (' . display_size($file->get_filesize()) . ')';
+
+                $filelistitems[] = html_writer::link($fileurl, $linktext);
+            }
+            sort($filelistitems);
+
+            $title = get_string('response_summary_files', 'qtype_questionpy');
+            $html .= $OUTPUT->render_from_template('assignsubmission_qpy/collapsible', [
+                'title' => $title . ' (' . count($files) . ')',
+                'content' => html_writer::alist($filelistitems, ['class' => 'm-1']),
+                'open' => $opened,
+            ]);
+        }
 
         if ($response) {
             ksort($response);
@@ -571,31 +596,6 @@ class assign_submission_qpy extends assign_submission_plugin {
             $html .= $OUTPUT->render_from_template('assignsubmission_qpy/collapsible', [
                 'title' => $title . ' (' . count($dynamicdatalistitems) . ')',
                 'content' => html_writer::alist($dynamicdatalistitems, ['class' => 'm-1 list-unstyled']),
-                'open' => $opened,
-            ]);
-        }
-
-        if ($files) {
-            $filelistitems = [];
-            foreach ($files as $file) {
-                $fileurl = moodle_url::make_pluginfile_url(
-                    $file->get_contextid(),
-                    $file->get_component(),
-                    $file->get_filearea(),
-                    $file->get_itemid(),
-                    $file->get_filepath(),
-                    $file->get_filename()
-                );
-                $linktext = $file->get_filename() . ' (' . display_size($file->get_filesize()) . ')';
-
-                $filelistitems[] = html_writer::link($fileurl, $linktext);
-            }
-            sort($filelistitems);
-
-            $title = get_string('response_summary_files', 'qtype_questionpy');
-            $html .= $OUTPUT->render_from_template('assignsubmission_qpy/collapsible', [
-                'title' => $title . ' (' . count($files) . ')',
-                'content' => html_writer::alist($filelistitems, ['class' => 'm-1']),
                 'open' => $opened,
             ]);
         }

--- a/locallib.php
+++ b/locallib.php
@@ -49,7 +49,7 @@ class assign_submission_qpy extends assign_submission_plugin {
     private const RESPONSE_FILES_AREA = 'qpy_response_files';
 
     /** @var int */
-    private const SUMMARY_MAX_ITEMS = 5;
+    private const COLLAPSIBLE_OPENED_THRESHOLD = 5;
 
     /**
      * Get the name of the qpy submission plugin.
@@ -505,60 +505,102 @@ class assign_submission_qpy extends assign_submission_plugin {
      * @throws moodle_exception
      */
     public function view_summary(stdClass $submission, &$showviewlink): string {
-        // The grading page has a long table. Do not display the full submission.
-        if (str_ends_with($_SERVER['SCRIPT_NAME'], 'view.php') && optional_param('action', '', PARAM_ALPHANUMEXT) === 'grading') {
-            $showviewlink = true; // Always show the link to view the attempt and history.
-            $quba = $this->get_question_usage($submission);
-            $attempt = $quba->get_question_attempt($quba->get_first_question_number());
-            $response = utils::get_qpy_response($attempt);
+        global $OUTPUT;
 
-            $fs = get_file_storage();
-            $files = $fs->get_area_files(
-                $this->assignment->get_context()->id,
-                'assignsubmission_qpy',
-                self::RESPONSE_FILES_AREA,
-                $submission->id,
-                includedirs: false
-            );
-            if ($response === null && !$files) {
-                return get_string('noqpyresponse', 'assignsubmission_qpy');
-            }
+        if (
+            !(str_ends_with($_SERVER['SCRIPT_NAME'], 'view.php') && optional_param('action', '', PARAM_ALPHANUMEXT) === 'grading')
+        ) {
+            // The grading page has a long table. Do not display the full submission.
+            return $this->view($submission, false);
+        }
 
-            if (isset($response->data) && !(array)$response->data) {
-                // Showing the dynamic JS data when it isn't used would just be confusing.
-                unset($response->data);
-            }
+        $showviewlink = true; // Always show the link to view the attempt and history.
+        $quba = $this->get_question_usage($submission);
+        $attempt = $quba->get_question_attempt($quba->get_first_question_number());
+        $response = utils::get_qpy_response($attempt);
+        $response = get_object_vars($response ?? (object) []);
 
-            if (count($files) + count((array) $response) > self::SUMMARY_MAX_ITEMS) {
-                return get_string('summarytoomanyitems', 'assignsubmission_qpy', a: [
-                    'responsefieldcount' => count((array) $response),
-                    'filecount' => count($files),
-                ]);
-            }
+        $fs = get_file_storage();
+        $files = $fs->get_area_files(
+            $this->assignment->get_context()->id,
+            'assignsubmission_qpy',
+            self::RESPONSE_FILES_AREA,
+            $submission->id,
+            includedirs: false
+        );
 
-            $html = '';
+        $dynamicdata = get_object_vars($response['data'] ?? (object) []);
+        unset($response['data']);
 
-            $listitems = [];
+        // Whether each collapsible should be open or closed.
+        $opened = count($response) + count($dynamicdata) + count($files) < self::COLLAPSIBLE_OPENED_THRESHOLD;
+
+        $html = '';
+
+        if ($response) {
+            ksort($response);
+
+            $responselistitems = [];
             foreach ($response as $responsekey => $responsevalue) {
-                assert(is_string($responsevalue));
-                $listitems[] = get_string('summaryresponsestring', 'assignsubmission_qpy', [
+                $responselistitems[] = get_string('summaryresponsestring', 'assignsubmission_qpy', [
                     'key' => s($responsekey),
                     'value' => s($responsevalue),
                 ]);
             }
-            if ($listitems) {
-                $html .= html_writer::alist($listitems, ['class' => 'm-1 list-unstyled']);
-            }
 
-            if ($files) {
-                $html .= get_string('summaryresponsefiles', 'assignsubmission_qpy', a: count($files));
-                $html .= $this->assignment->render_area_files('assignsubmission_qpy', self::RESPONSE_FILES_AREA, $submission->id);
-            }
-
-            return $html;
+            $title = get_string('response_summary_form_data', 'qtype_questionpy');
+            $html .= $OUTPUT->render_from_template('assignsubmission_qpy/collapsible', [
+                'title' => $title . ' (' . count($responselistitems) . ')',
+                'content' => html_writer::alist($responselistitems, ['class' => 'm-1 list-unstyled']),
+                'open' => $opened,
+            ]);
         }
 
-        return $this->view($submission, false);
+        if ($dynamicdata) {
+            ksort($dynamicdata);
+
+            $dynamicdatalistitems = [];
+            foreach ($dynamicdata as $dynamicdatakey => $dynamicdatavalue) {
+                $dynamicdatalistitems[] = get_string('summaryresponsestring', 'assignsubmission_qpy', [
+                    'key' => s($dynamicdatakey),
+                    'value' => s(json_encode($dynamicdatavalue)),
+                ]);
+            }
+
+            $title = get_string('response_summary_dynamic_data', 'qtype_questionpy');
+            $html .= $OUTPUT->render_from_template('assignsubmission_qpy/collapsible', [
+                'title' => $title . ' (' . count($dynamicdatalistitems) . ')',
+                'content' => html_writer::alist($dynamicdatalistitems, ['class' => 'm-1 list-unstyled']),
+                'open' => $opened,
+            ]);
+        }
+
+        if ($files) {
+            $filelistitems = [];
+            foreach ($files as $file) {
+                $fileurl = moodle_url::make_pluginfile_url(
+                    $file->get_contextid(),
+                    $file->get_component(),
+                    $file->get_filearea(),
+                    $file->get_itemid(),
+                    $file->get_filepath(),
+                    $file->get_filename()
+                );
+                $linktext = $file->get_filename() . ' (' . display_size($file->get_filesize()) . ')';
+
+                $filelistitems[] = html_writer::link($fileurl, $linktext);
+            }
+            sort($filelistitems);
+
+            $title = get_string('response_summary_files', 'qtype_questionpy');
+            $html .= $OUTPUT->render_from_template('assignsubmission_qpy/collapsible', [
+                'title' => $title . ' (' . count($files) . ')',
+                'content' => html_writer::alist($filelistitems, ['class' => 'm-1']),
+                'open' => $opened,
+            ]);
+        }
+
+        return $html ?: get_string('noqpyresponse', 'assignsubmission_qpy');
     }
 
     /**

--- a/templates/collapsible.mustache
+++ b/templates/collapsible.mustache
@@ -1,0 +1,47 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+
+    @template assignsubmission_qpy/collapsable_section
+
+    Small collapsible section. Inspired by core/local/collapsable_section.
+
+    Optional blocks:
+    * titlecontent - the collpasible title content.
+    * sectioncontent - the collapsible content.
+    * open - whether the collapsible section is open.
+
+    Example context (json):
+    {
+        "title": "Title",
+        "content": "Content",
+        "open": true
+    }
+}}
+<div>
+    <a data-bs-toggle="collapse"
+       href="#assignsubmission_qpy-collapse-{{uniqid}}"
+       role="button"
+        {{#open}} aria-expanded="true" {{/open}}
+        {{^open}} aria-expanded="false" {{/open}}
+       aria-controls="assignsubmission_qpy-collapse-{{uniqid}}">
+        {{title}}
+    </a>
+    <div class="collapse {{#open}}show{{/open}}" id="assignsubmission_qpy-collapse-{{uniqid}}">
+        {{{content}}}
+    </div>
+</div>

--- a/templates/collapsible.mustache
+++ b/templates/collapsible.mustache
@@ -21,8 +21,8 @@
     Small collapsible section. Inspired by core/local/collapsable_section.
 
     Optional blocks:
-    * titlecontent - the collpasible title content.
-    * sectioncontent - the collapsible content.
+    * title - the title content.
+    * content - the collapsible content.
     * open - whether the collapsible section is open.
 
     Example context (json):


### PR DESCRIPTION
Zeigt die Daten einer Submission in einklappbaren Containern an.
 
Zuerst hatte ich versucht die in Moodle 5.0 hinzugefügte [Collapsable-Section-Komponente](https://componentlibrary.moodle.com/admin/tool/componentlibrary/docspage.php/moodle/components/collapsable-sections/) zu verwenden, allerdings lässt sich nicht so einfach die Größe des Titels und Buttons ändern. Deshalb habe ich jetzt einfach ein simples Template erstellt.

Zuvor wurde auch ein Fehler geschmissen, wenn dynamische Daten existiert haben.

<img width="156" height="288" alt="image" src="https://github.com/user-attachments/assets/85ddb51f-06ba-43cd-ab05-74a835353c29" />

<img width="157" height="191" alt="image" src="https://github.com/user-attachments/assets/4a6c9ad2-1b00-469c-9237-5e8cd4a23c92" />
