### PR TITLE
Check-Button auf der View-Seite verstecken

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,12 @@
  * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** Hide the question info box with the question number, status and score. */
 .path-mod-assign .que.questionpy > div.info {
+    display: none;
+}
+
+/** Hide the question behaviour submit "Check" button on the read-only view page. */
+#page-mod-assign-view .que .im-controls button[name$='-submit'] {
     display: none;
 }


### PR DESCRIPTION
Die Behaviours fügen den Button mittels der Methode `\qbehaviour_renderer::submit_button` hinzu. Die sind deshalb einheitlich und lassen sich auf der Haupt/View-Seite von mod_assign mit der read-only Ansicht der Frage leicht ausblenden.

Der deaktivierte Button ist an der Stelle verwirrend und unnötig.